### PR TITLE
Added DevOps installation and upgrade documentation

### DIFF
--- a/docs/en/install/installing-devops.mdx
+++ b/docs/en/install/installing-devops.mdx
@@ -3,7 +3,7 @@ weight: 30
 sourceSHA: b49eb75e9882f9179094b757c4f51359bcc7cafa83afb70016d43a89b5af8c52
 ---
 
-# Installing DevOps
+# Installing Alauda DevOps
 
 This guide provides detailed steps for installing `Alauda DevOps`.
 
@@ -86,7 +86,7 @@ Deploy Katanomi instances in the Global cluster. The business cluster can deploy
 
   ### Preparation CI/CD Environment
 
-  Before officially using the builds and releases features of DevOps, platform administrators need to complete some preparation.
+  Before officially using the builds and releases features of Alauda DevOps, platform administrators need to complete some preparation.
 
   Refer to the documentation: `<Platform URL>/console-devops-docs/en/devops-initialization/cicd/init/`
   

--- a/docs/zh/install/installing-devops.mdx
+++ b/docs/zh/install/installing-devops.mdx
@@ -3,7 +3,7 @@ weight: 30
 sourceSHA: ccaa1c8e4e23d844be4f03964ea4cb19f573151216a6f9770b3840657401eda7
 ---
 
-# 安装 DevOps
+# 安装 Alauda DevOps
 
 本指南提供了安装 `Alauda DevOps` 的详细步骤。
 
@@ -26,7 +26,7 @@ sourceSHA: ccaa1c8e4e23d844be4f03964ea4cb19f573151216a6f9770b3840657401eda7
 
   <tr>
     <td>Katanomi</td>
-    <td>已安装</td>
+    <td>必装</td>
     <td>可选</td>
   </tr>
 </table>

--- a/docs/zh/upgrade/upgrading-devops.mdx
+++ b/docs/zh/upgrade/upgrading-devops.mdx
@@ -3,6 +3,6 @@ weight: 30
 sourceSHA: af51921e973f937ab9de9c2ea33ff3c7c6e4b124986f96a0c85f627acb19c30a
 ---
 
-# 升级 DevOps 组件
+# 升级 Alauda DevOps 组件
 
 DevOps 组件在平台升级时会自动升级，无需人工干预。系统在后台无缝处理所有必要的迁移和更新。


### PR DESCRIPTION
- Added detailed steps to install Alauda DevOps, including prerequisites and deployment locations.
- Added steps and parameters for creating a Katanomi instance.
- Updated upgrade documentation for traditional DevOps components to emphasize automatic upgrades without human intervention.
- Removed legacy DevOps installation and upgrade documentation.