### PR TITLE
Upgrading Alauda DevOps from ACP 3.18 to 4.1.

### DIFF
--- a/docs/en/upgrade/upgrading-devops.mdx
+++ b/docs/en/upgrade/upgrading-devops.mdx
@@ -5,4 +5,57 @@ sourceSHA: 03b11615a739095db87029e6b3ad9b9986a42c6033f4d265744147def3832b5a
 
 # Upgrading Alauda DevOps
 
-Alauda DevOps components are designed to upgrade automatically during platform upgrades, requiring no manual intervention. The system handles all necessary migrations and updates seamlessly in the background.
+This guide details the upgrade strategy and procedures for `Alauda DevOps Operators` when upgrading from `Alauda Container Platform (ACP) 3.18` to `ACP 4.1`.
+
+## Version Compatibility Matrix
+
+The following table shows the version requirements for `Alauda DevOps Operators` when upgrading from `ACP 3.18` to `4.1`.
+
+| Alauda DevOps Operator    | Version   |
+| ------------------------- | --------- |
+| Katanomi                  | v3.20.z   |
+| Knative                   | v3.20.z   |
+| Alauda DevOps Jenkins v3  | v3.20.z   |
+| Alauda DevOps Pipelines   | v4.0.z    |
+| Alauda Build of Gitlab    | v17.8.z   |
+| Alauda Build of Harbor    | v2.12.z   |
+| Alauda Build of SonarQube | v2025.1.z |
+| Alauda Build of Nexus     | v3.76.z   |
+
+:::info
+The `.z` in version numbers indicates the latest available patch version for that minor release. During upgrade, you should always use the latest patch version to benefit from the most recent security updates and bug fixes.
+:::
+
+## Prerequisites
+
+You have two options for preparing the upgrade package:
+
+1. **Combined Package**: Merge the `ACP` core package with the `DevOps` extension package. To obtain the extension package, you can download `Alauda DevOps Operators` in bulk or as needed through the **Customer Portal**. For detailed instructions on obtaining the installation package, refer to <ExternalSiteLink name="container_platform" href="install/prepare/download.html" children="Downloading Operators" />.
+2. **Separate Packages**: If you choose not to combine the packages, prepare `Alauda DevOps Operators` separately and manually upload them after completing the `ACP` platform upgrade. For specific instructions, refer to <ExternalSiteLink name="container_platform" href="ui/cli_tools/#downloading-the-tool" children="Uploading Operators" />.
+
+**Upgrading ACP**
+
+Upgrade the `ACP` platform to version 4.1. For detailed instructions, refer to <ExternalSiteLink name="container_platform" href="upgrade/overview.html" children="Upgrading Container Platform" />.
+
+## Upgrading Alauda DevOps
+
+### Upgrade Operators via Migration {#Migration}
+
+After completing the `ACP` upgrade, upgrade the following Operators as documented:
+
+- [Upgrading Alauda DevOps Pipelines](https://docs.alauda.io/devops/4.0/upgrade/migrating-tekton-v3-to-v4.md.html)
+- [Upgrading Alauda Build of Gitlab](https://docs.alauda.io/alauda-build-of-gitlab/17.8/upgrade/02_14_upgrade_to_17.html)
+- [Upgrading Alauda Build of Harbor](https://docs.alauda.io/alauda-build-of-harbor/2.12/upgrade/01_upgrade_2.6.4_to_2.12.html)
+- [Upgrading Alauda Build of SonarQube](https://docs.alauda.io/alauda-build-of-sonarqube/2025.1/upgrade/05_upgrade_to_2025.1.0.html)
+- [Upgrading Alauda Build of Nexus](https://docs.alauda.io/alauda-build-of-nexus/3.76/upgrade/migrate_to_3.76.0.html)
+
+### Upgrading Operators via UI {#UI}
+
+For `Katanomi`, `Knative`, and `Alauda DevOps Jenkins v3` Operators, complete the upgrade through the UI after the `ACP` upgrade:
+
+Navigate to `Administrator` -> `Marketplace` -> `Operator Hub`, switch to the target cluster and enter the corresponding Operator details page. Click the instance name you want to upgrade to enter the instance details page, then follow the instructions to complete the upgrade.
+
+## Next Steps
+
+You have now completed the upgrade of `Alauda DevOps Operators` in the `ACP 3.18` to `4.1` upgrade scenario. However, the Operators upgraded via [Upgrade via Migration](#Migration) may not be the latest available versions. You can contact technical support to obtain the latest Operators and continue upgrading to the latest version using the [Upgrading Instances via UI](#UI) method.
+

--- a/sites.yaml
+++ b/sites.yaml
@@ -3,7 +3,7 @@
     en: Alauda DevOps Pipelines
     zh: Alauda DevOps Pipelines
   base: /alauda-devops-pipelines
-  version: v4.0
+  version: v4.2
   repo: https://github.com/AlaudaDevops/tektoncd-operator
   image: devops/alauda-devops-pipelines-docs
 - name: alauda-devops-connectors
@@ -11,7 +11,7 @@
     en: Alauda DevOps Connectors
     zh: Alauda DevOps Connectors
   base: /alauda-devops-connectors
-  version: v1.0
+  version: v1.1
   repo: https://github.com/AlaudaDevops/connectors-operator
   image: devops/alauda-devops-connectors-docs
 - name: alauda-build-of-gitlab
@@ -19,7 +19,7 @@
     en: Alauda Build of Gitlab
     zh: Alauda Build of Gitlab
   base: /alauda-build-of-gitlab
-  version: v17.8
+  version: v17.11
   repo: https://github.com/AlaudaDevops/gitlab-ce-operator
   image: devops/alauda-build-of-gitlab-docs
 - name: alauda-build-of-harbor
@@ -35,7 +35,7 @@
     en: Alauda Build of Nexus
     zh: Alauda Build of Nexus
   base: /alauda-build-of-nexus
-  version: v3.76
+  version: v3.81
   repo: https://github.com/AlaudaDevops/nexus-ce-operator
   image: devops/alauda-build-of-nexus-docs
 - name: alauda-build-of-sonarqube
@@ -48,4 +48,4 @@
   image: devops/alauda-build-of-sonarqube-docs
 - name: container_platform
   base: /container_platform
-  version: v4.0
+  version: v4.1


### PR DESCRIPTION
Alauda DevOps Upgrade in ACP 3.18 to 4.1 Upgrade Scenarios.