### PR TITLE
chore: add v3 plugin release notes

### DIFF
--- a/docs/en/jenkins/index.mdx
+++ b/docs/en/jenkins/index.mdx
@@ -1,0 +1,8 @@
+---
+weight: 900
+sourceSHA: bc41c3854a0b20a2af73129062603452edf9a9bcb8314eced8b5b24b368a4d1d
+---
+
+# Alauda Devops Jenkins v3
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/jenkins/lifecycle_policy.mdx
+++ b/docs/en/jenkins/lifecycle_policy.mdx
@@ -1,0 +1,19 @@
+---
+weight: 30
+---
+
+## Alauda DevOps Jenkins v3 - 3.20
+
+### Version Lifecycle
+
+#### Version Lifecycle Timeline
+
+Below is the life cycle schedule for released versions of the `Alauda DevOps Jenkins v3` operator:
+
+| Version  | Release Date  | End of Support  |
+| -------- | ------------- | --------------- |
+| v3.20.x  | 2025-04-08    |   2026-04-08    |
+
+### Release Policy
+
+As this component has entered the maintenance phase, no new feature releases will be provided. A patch release containing security updates and bug fixes will be issued every two months.

--- a/docs/en/jenkins/release_notes.mdx
+++ b/docs/en/jenkins/release_notes.mdx
@@ -1,0 +1,48 @@
+---
+weight: 40
+i18n:
+  title:
+    en: Release Notes
+sourceSHA: 5c6c24ac29b19764d02d88d43635e98fda9465590462e895d47bfcd81703629c
+title: Release Notes
+---
+
+# Release Notes
+
+## Alauda DevOps Jenkins v3 - 3.20
+
+### Compatibility and support matrix
+
+The following table shows the compatibility and support matrix between the Alauda Build of `Alauda DevOps Jenkins v3` operator and ACP versions.
+
+| Alauda DevOps Jenkins v3 Operator Version | ACP Version     | Support MicroOS |
+| ---------------------------------         | --------------- | --------------  |
+| v3.20.15                                  | v4.0, v4.1      | no              |
+| v3.20.8                                   | v4.0            | no              |
+
+
+### v3.20.15
+
+#### New and Optimized Features
+
+Support integrating DevOps Jenkins v3 with Dev Tools v4 (e.g., GitLab CE 17.11, Harbor 1.12.4).
+
+#### Fixed Issues
+
+{/* release-notes-for-bugs?template=fixed&project=DEVOPS&version=v3.20.15 */}
+
+#### Known Issues
+
+{/* release-notes-for-bugs?template=unfixed&project=DEVOPS&version=v3.20.15 */}
+
+### v3.20.8
+
+#### New and Optimized Features
+
+#### Fixed Issues
+
+{/* release-notes-for-bugs?template=fixed&project=DEVOPS&version=v3.20.8 */}
+
+#### Known Issues
+
+{/* release-notes-for-bugs?template=unfixed&project=DEVOPS&version=v3.20.8 */}

--- a/docs/en/katanomi/index.mdx
+++ b/docs/en/katanomi/index.mdx
@@ -1,0 +1,8 @@
+---
+weight: 700
+sourceSHA: bc41c3854a0b20a2af73129062603452edf9a9bcb8314eced8b5b24b368a4d1d
+---
+
+# Alauda Devops v3
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/katanomi/lifecycle_policy.mdx
+++ b/docs/en/katanomi/lifecycle_policy.mdx
@@ -1,0 +1,19 @@
+---
+weight: 30
+---
+
+## Alauda DevOps v3 - 3.20
+
+### Version Lifecycle
+
+#### Version Lifecycle Timeline
+
+Below is the life cycle schedule for released versions of the `Alauda DevOps v3` operator:
+
+| Version  | Release Date  | End of Support  |
+| -------- | ------------- | --------------- |
+| v3.20.x  | 2025-04-08    |   2026-04-08    |
+
+### Release Policy
+
+As this component has entered the maintenance phase, no new feature releases will be provided. A patch release containing security updates and bug fixes will be issued every two months.

--- a/docs/en/katanomi/release_notes.mdx
+++ b/docs/en/katanomi/release_notes.mdx
@@ -1,0 +1,88 @@
+---
+weight: 40
+i18n:
+  title:
+    en: Release Notes
+sourceSHA: 5c6c24ac29b19764d02d88d43635e98fda9465590462e895d47bfcd81703629c
+title: Release Notes
+---
+
+# Release Notes
+
+## Alauda DevOps v3 - 3.20
+
+### Compatibility and support matrix
+
+The following table shows the compatibility and support matrix between the Alauda Build of `Alauda DevOps v3` operator and ACP versions.
+
+  | Alauda DevOps v3 Operator Version | ACP Version     | Support MicroOS |
+  | --------------------------------- | --------------- | ------------    |
+  | v3.20.31                          | v4.0, v4.1      | no              |
+  | v3.20.28                          | v4.0            | no              |
+  | v3.20.23                          | v4.0            | no              |
+  | v3.20.13                          | v4.0            | no              |
+
+### v3.20.31
+
+#### New and Optimized Features
+
+Users can integrate DevOps Jenkins v3 with Dev Tools v4 (e.g., GitLab CE 17.11, Harbor 1.12.4).
+
+
+#### Fixed Issues
+
+{/* release-notes-for-bugs?template=fixed&project=DEVOPS&version=v3.20.31 */}
+
+#### Known Issues
+
+{/* release-notes-for-bugs?template=unfixed&project=DEVOPS&version=v3.20.31 */}
+
+### v3.20.28
+
+#### New and Optimized Features
+
+#### Fixed Issues
+
+{/* release-notes-for-bugs?template=fixed&project=DEVOPS&version=v3.20.28 */}
+
+#### Known Issues
+
+{/* release-notes-for-bugs?template=unfixed&project=DEVOPS&version=v3.20.28 */}
+
+### v3.20.23
+
+#### New and Optimized Features
+
+#### Fixed Issues
+
+{/* release-notes-for-bugs?template=fixed&project=DEVOPS&version=v3.20.23 */}
+
+#### Known Issues
+
+{/* release-notes-for-bugs?template=unfixed&project=DEVOPS&version=v3.20.23 */}
+
+
+### v3.20.13
+
+#### New and Optimized Features
+
+
+##### Toolchain Instance Management, Platform scoped Integrations, and Pipeline Templates and configurations moved to Alauda DevOps
+
+Previously the toolchain instance management, platform scoped integrations, and pipeline templates and configurations were part of the Platform Management module. With the new release, this feature has been moved to Alauda DevOps. Platform Administrators can now switch to Platform Management functionality inside of Alauda DevOps.
+
+##### Project scoped Integrations and Pipelines Templates moved to Alauda DevOps
+
+Previously the project scoped integrations and pipelines templates were part of the Project Management module. With the new release, this feature has been moved to Alauda DevOps. Project Administrators can now switch to Project Management functionality inside of Alauda DevOps.
+
+##### Release Pipelines Template parameters
+
+Users can specify which parameters are used when executing a release pipeline when saving a pipeline template. This change empowers platform builders to create more flexible and reusable release pipelines and improves overall speed of pipeline creation.
+
+#### Fixed Issues
+
+{/* release-notes-for-bugs?template=fixed&project=DEVOPS&version=v3.20.13 */}
+
+#### Known Issues
+
+{/* release-notes-for-bugs?template=unfixed&project=DEVOPS&version=v3.20.13 */}

--- a/docs/en/knative/index.mdx
+++ b/docs/en/knative/index.mdx
@@ -1,0 +1,8 @@
+---
+weight: 800
+sourceSHA: bc41c3854a0b20a2af73129062603452edf9a9bcb8314eced8b5b24b368a4d1d
+---
+
+# Alauda Devops Eventing v3
+
+<Overview overviewHeaders={[]} />

--- a/docs/en/knative/lifecycle_policy.mdx
+++ b/docs/en/knative/lifecycle_policy.mdx
@@ -1,0 +1,19 @@
+---
+weight: 30
+---
+
+## Alauda DevOps Eventing v3 - 3.20
+
+### Version Lifecycle
+
+#### Version Lifecycle Timeline
+
+Below is the life cycle schedule for released versions of the `Alauda DevOps Eventing v3` operator:
+
+| Version  | Release Date  | End of Support  |
+| -------- | ------------- | --------------- |
+| v3.20.x  | 2025-04-08    |   2026-04-08    |
+
+### Release Policy
+
+As this component has entered the maintenance phase, no new feature releases will be provided. A patch release containing security updates and bug fixes will be issued every two months.

--- a/docs/en/knative/release_notes.mdx
+++ b/docs/en/knative/release_notes.mdx
@@ -1,0 +1,46 @@
+---
+weight: 40
+i18n:
+  title:
+    en: Release Notes
+sourceSHA: 5c6c24ac29b19764d02d88d43635e98fda9465590462e895d47bfcd81703629c
+title: Release Notes
+---
+
+# Release Notes
+
+## Alauda DevOps Eventing v3 - 3.20
+
+### Compatibility and support matrix
+
+The following table shows the compatibility and support matrix between the Alauda Build of `Alauda DevOps Eventing v3` operator and ACP versions.
+
+| Alauda DevOps v3 Operator Version | ACP Version     | Support MicroOS |
+| --------------------------------- | --------------- | --------------- |
+| v3.20.6                           | v4.0, v4.1      | no              |
+| v3.20.2                           | v4.0            | no              |
+
+
+### v3.20.6
+
+#### New and Optimized Features
+
+#### Fixed Issues
+
+{/* release-notes-for-bugs?template=fixed&project=DEVOPS&version=v3.20.6 */}
+
+#### Known Issues
+
+{/* release-notes-for-bugs?template=unfixed&project=DEVOPS&version=v3.20.6 */}
+
+### v3.20.2
+
+#### New and Optimized Features
+
+#### Fixed Issues
+
+{/* release-notes-for-bugs?template=fixed&project=DEVOPS&version=v3.20.2 */}
+
+#### Known Issues
+
+{/* release-notes-for-bugs?template=unfixed&project=DEVOPS&version=v3.20.2 */}

--- a/docs/en/upgrade/upgrading-devops-v3-to-v4.mdx
+++ b/docs/en/upgrade/upgrading-devops-v3-to-v4.mdx
@@ -13,8 +13,8 @@ The following table shows the version requirements for `Alauda DevOps Operators`
 
 | Alauda DevOps Operator    | Version   |
 | ------------------------- | --------- |
-| Katanomi                  | v3.20.z   |
-| Knative                   | v3.20.z   |
+| Alauda Devops v3          | v3.20.z   |
+| Alauda Devops Eventing v3 | v3.20.z   |
 | Alauda DevOps Jenkins v3  | v3.20.z   |
 | Alauda DevOps Pipelines   | v4.0.z    |
 | Alauda Build of Gitlab    | v17.8.z   |
@@ -53,7 +53,7 @@ After completing the `ACP` upgrade, upgrade the following Operators as documente
 
 ### Upgrading Operators via UI {#UI}
 
-For `Katanomi`, `Knative`, and `Alauda DevOps Jenkins v3` Operators, complete the upgrade through the UI after the `ACP` upgrade:
+For `Alauda Devops v3` (`Katanomi`), `Alauda Devops Eventing v3` (`Knative`), and `Alauda DevOps Jenkins v3` Operators, complete the upgrade through the UI after the `ACP` upgrade:
 
 Navigate to `Administrator` -> `Marketplace` -> `Operator Hub`, switch to the target cluster and enter the corresponding Operator details page. Click the instance name you want to upgrade to enter the instance details page, then follow the instructions to complete the upgrade.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added new docs sections for Alauda DevOps Jenkins v3, Alauda Devops v3, and Alauda Devops Eventing v3, including index pages with Overview components.
  - Introduced lifecycle policies for v3.20 series with timelines and maintenance release policy.
  - Published release notes with compatibility matrices and per-version sections (features, fixes, known issues) using templates.
  - Updated upgrade guide: renamed Katanomi/Knative to Alauda Devops v3/Eventing v3 and added Harbor and SonarQube Build operators to the compatibility matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->