### PR TITLE
docs:upgrading Alauda DevOps from ACP 3.18 to 4.x.

### DIFF
--- a/docs/en/upgrade/upgrading-devops-v3-to-v4.mdx
+++ b/docs/en/upgrade/upgrading-devops-v3-to-v4.mdx
@@ -3,18 +3,18 @@ weight: 30
 sourceSHA: 03b11615a739095db87029e6b3ad9b9986a42c6033f4d265744147def3832b5a
 ---
 
-# Upgrading `Alauda DevOps v3` to `Alauda DevOps v4`
+# Upgrading `Alauda DevOps` to `Alauda DevOps (Next-Gen)`
 
-This guide details the upgrade strategy and procedures for `Alauda DevOps v3` to `Alauda DevOps v4` when upgrading from `Alauda Container Platform v3.18` to `v4.0` or `v4.1`.
+This guide details the upgrade strategy and procedures for `Alauda DevOps` to `Alauda DevOps (Next-Gen)` when upgrading from `Alauda Container Platform v3.18` to `v4.0` or `v4.1`.
 
-## Version Compatibility Matrix
+## Version Compatibility Matrix {#Version}
 
 The following table shows the version requirements for `Alauda DevOps Operators` when upgrading from `ACP v3` to `v4`.
 
 | Alauda DevOps Operator    | Version   |
 | ------------------------- | --------- |
-| Katanomi                  | v3.20.z   |
-| Knative                   | v3.20.z   |
+| Alauda DevOps v3          | v3.20.z   |
+| Alauda DevOps Eventing v3 | v3.20.z   |
 | Alauda DevOps Jenkins v3  | v3.20.z   |
 | Alauda DevOps Pipelines   | v4.0.z    |
 | Alauda Build of Gitlab    | v17.8.z   |
@@ -26,24 +26,31 @@ The following table shows the version requirements for `Alauda DevOps Operators`
 The `.z` in version numbers indicates the latest available patch version for that minor release. During upgrade, you should always use the latest patch version to benefit from the most recent security updates and bug fixes.
 :::
 
+:::note
+
+Special Note: In the scenario where `ACP v3.18` is upgraded to `v4.0` or `v4.1`, Alauda DevOps Pipelines only supports version `v4.0`.
+
+:::
+
 ## Prerequisites
 
-You have two options for preparing the upgrade package:
+### Upgrade ACP Platform
 
-1. **Combined Package**: Merge the `ACP` core package with the `DevOps` extension package. To obtain the extension package, you can download `Alauda DevOps Operators` in bulk or as needed through the **Customer Portal**. For detailed instructions on obtaining the installation package, refer to <ExternalSiteLink name="container_platform" href="install/prepare/download.html" children="Downloading Operators" />.
-2. **Separate Packages**: If you choose not to combine the packages, prepare `Alauda DevOps Operators` separately and manually upload them after completing the `ACP` platform upgrade. For specific instructions, refer to <ExternalSiteLink name="container_platform" href="ui/cli_tools/#downloading-the-tool" children="Uploading Operators" />.
+First, upgrade the `ACP` platform to version `v4`. For detailed instructions, refer to  <ExternalSiteLink name="container_platform"  href="upgrade/overview.html" children="Upgrading Container Platform"  />.
+
+### Prepare Extension Packages
+
+After completing the `ACP` platform upgrade, you need to separately prepare the `Alauda DevOps Operators` and upload them. For specific operation steps, refer to  <ExternalSiteLink name="container_platform"  href="ui/cli_tools/#downloading-the-tool" children="Uploading Operators" />.
+
 :::note
-When downloading the `DevOps` extension package, it is recommended to select the `Alauda DevOps V3 Upgrade` batch download template in the **Customer Portal**. With this template, you can quickly obtain the upgrade package and improve download efficiency.
+When downloading the DevOps extension package, you can download it in batches or individually based on the `Alauda DevOps V3 Upgrade` template in the **Customer Portal**. The relevant version of the corresponding operator needs to be consistent with the version of  [Version Compatibility Matrix](#Version).
 :::
-**Upgrading ACP**
-
-Upgrade the `ACP` platform to version `v4`. For detailed instructions, refer to <ExternalSiteLink name="container_platform" href="upgrade/overview.html" children="Upgrading Container Platform" />.
 
 ## Upgrading Alauda DevOps
 
 ### Upgrade Operators via Migration {#Migration}
 
-After completing the `ACP` upgrade, upgrade the following Operators as documented:
+After completing the prerequisites, upgrade the following `Operators` as documented:
 
 - [Migrating Alauda DevOps Pipelines](./migrating-tekton-v3-to-v4.mdx)
 - [Migrating Alauda Build of Gitlab](https://docs.alauda.io/alauda-build-of-gitlab/17.8/upgrade/02_14_upgrade_to_17.html)
@@ -53,11 +60,11 @@ After completing the `ACP` upgrade, upgrade the following Operators as documente
 
 ### Upgrading Operators via UI {#UI}
 
-For `Katanomi`, `Knative`, and `Alauda DevOps Jenkins v3` Operators, complete the upgrade through the UI after the `ACP` upgrade:
+For `Alauda DevOps v3`, `Alauda DevOps Eventing v3`, and `Alauda DevOps Jenkins v3`, complete the upgrade through the UI after the `ACP` upgrade:
 
 Navigate to `Administrator` -> `Marketplace` -> `Operator Hub`, switch to the target cluster and enter the corresponding Operator details page. Click the instance name you want to upgrade to enter the instance details page, then follow the instructions to complete the upgrade.
 
 ## Next Steps
 
-You have now completed the upgrade of `Alauda DevOps Operators` in the `ACP v3` to `v4` upgrade scenario. However, the Operators upgraded via [Upgrade via Migration](#Migration) may not be the latest available versions. You can contact technical support to obtain the latest Operators and continue upgrading to the latest version using the [Upgrading Instances via UI](#UI) method.
+You have now completed the upgrade of `Alauda DevOps` in the `ACP v3` to `v4` upgrade scenario. However, the `Operators` upgraded via [Upgrade via Migration](#Migration) may not be the latest available versions. You can contact technical support to obtain the latest Operators and continue upgrading to the latest version using the [Upgrading Instances via UI](#UI) method.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Rebranded upgrade guide to “Alauda DevOps (Next-Gen).”
  - Expanded Version Compatibility Matrix, including Alauda DevOps v3, Alauda DevOps Eventing v3, and build tools (Harbor, SonarQube, Nexus).
  - Added special note: during ACP v3.18 → v4.x, Pipelines supports v4.0 only.
  - Reorganized prerequisites to prioritize platform upgrade, then operator uploads.
  - Streamlined packaging guidance to align with the compatibility matrix.
  - Updated operator migration and UI upgrade steps and terminology.
  - Refreshed cross-references and Next Steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->