### PR TITLE
docs:update Alauda DevOps (Next-Gen) v4.1 release notes and sites.yaml.

### DIFF
--- a/docs/en/overview/lifecycle_policy.mdx
+++ b/docs/en/overview/lifecycle_policy.mdx
@@ -2,7 +2,7 @@
 weight: 30
 ---
 
-## Alauda DevOps (Next-Gen) - 4.0
+## Alauda DevOps (Next-Gen) - 4.1
 
 ### Version Lifecycle & Release Policy
 

--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -1,5 +1,5 @@
 ---
-weight: 10
+weight: 40
 i18n:
   title:
     en: Release Notes (Next-Gen)
@@ -60,10 +60,13 @@ This update enhances the overall security and stability of the toolchain, which 
 
 ### Fixed Issues
 
-- Fixed an issue in `Alauda DevOps Pipeline` where the `ConfigMap` key  displayed in the UI did not match the actual execution.
-- Fixed several issues in `Alauda DevOps Pipeline`, including failure to delete `Tekton` components, trigger resources not being automatically  imported, and the creation of zombie processes by tekton-hub-api.
-- Fixed several stability-related issues in `Alauda DevOps Pipeline`.
+{/* release-notes-for-bugs?template=fixedIssues&project=DEVOPS&version=(fixVersion ~ "connectors-operator-v1.2.*" OR fixVersion ~ "connectors-operator-v1.1.*" OR fixVersion ~ "tektoncd-operator-v4.2.*" OR fixVersion ~ "tektoncd-operator-v4.1.*" OR fixVersion ~ "gitlab-ce-operator-v17.11.*" OR fixVersion ~ "nexus-ce-operator-v3.81.*") */}
 
 ### Known Issues
 
-No issues in this release.
+{/* release-notes-for-bugs?template=unfixedIssues&project=DEVOPS&version=(affectedVersion ~ "connectors-operator-v1.2.*" OR affectedVersion ~ "connectors-operator-v1.1.*" OR affectedVersion ~ "tektoncd-operator-v4.2.*" OR affectedVersion ~ "tektoncd-operator-v4.1.*" OR affectedVersion ~ "gitlab-ce-operator-v17.11.*" OR affectedVersion ~ "nexus-ce-operator-v3.81.*") */}
+
+
+
+
+

--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -9,29 +9,61 @@ title: Release Notes
 
 # Release Notes
 
-## Alauda DevOps (Next-Gen) - 4.0
+:::info
+The release notes include aggregated content for multiple versions of each `Operator` in the `Alauda DevOps v4.1` compatibility matrix. More detailed release notes for each `Operator` can be further viewed in the corresponding `Operator` documentation center.
+:::
+
+## Alauda DevOps (Next-Gen) - 4.1
+
+### Compatibility and Support Matrix
+
+The table below shows the version matrix of the `Operators` included in `Alauda DevOps v4.1`.
+
+| Alauda DevOps Version | Alauda DevOps Pipeline Version | Alauda DevOps Connectors Version | Toolchain Version                                            |
+| --------------------- | ------------------------------ | -------------------------------- | ------------------------------------------------------------ |
+| v4.1                  | v4.1, v4.2                     | v1.1, v1.2                       | Alauda Build of Gitlab: v17.11<br /> Alauda Build of Harbor: v2.12<br />Alauda Build of SonarQube: v2025.1<br />Alauda Build of Nexus: v3.81 |
+
+
 
 ### New and Optimized Features
 
-#### Alauda DevOps Pipelines v4.0
+#### Alauda DevOps Pipeline
 
-Based directly on Tekton and its APIs, Alauda DevOps Pipelines provides a more user-friendly and efficient way to build and manage pipelines. With an intuitive interface and a rich set of features, users can easily create and manage pipelines, and get real-time feedback and insights.
+- Task Functionality Enhancement: New task types added, including `kubectl`, `git`, `Python`, and `Pytest`; standardized pipeline templates for `Java` and `Python` provided.
+- Security Capabilities Upgrade: Integrated `syft`, `cosign`, and `trivy` tasks to enable image SBOM generation, signature verification, and vulnerability scanning.
+- Configuration Enhancement: Supports pipeline trigger templates; `EventListener` now supports custom `securityContext` and `imagePullSecrets` configurations.
+- User Experience Optimization: End-to-end experience optimization for pipeline orchestration.
+- Tekton Community Upstream Issues Optimized.
 
-#### Alauda DevOps Connectors v1.0 (Alpha)
+#### Alauda DevOps Connectors
 
-Connectors provide a secure and efficient way to connect to external services and tools and provide an unobtrusive way to integrate with them. Platform teams can easily and securely create connectors while keeping access secrets protected.
+- Supports using the `OCI Connector` when pulling images in `Kubernetes`.
+- Adds a new `Kubernetes Connector` to integrate with `Kubernetes` clusters and use it in workloads/pipelines.
 
-#### DevOps Toolchain
+#### DevOps Toolchain 
 
-Provides a easy deployable DevOps toolchain instances with a set of deployment templates to increase deployment speed and confidence while keeping full customizability. Includes:
+This update enhances the overall security and stability of the toolchain, which includes the following:
 
-- Alauda Build of Gitlab v17.8
-- Alauda Build of Harbor v2.12
-- Alauda Build of SonarQube v2025.1
-- Alauda Build of Nexus v3.76
+- Alauda Build of Gitlab
 
-A complete step-by-step migration guide from previous DevOps legacy toolchain is provided within the addon's documentation.
+-  Alauda Build of Harbor
 
-#### Release Pipelines Template parameters
+- Alauda Build of SonarQube
 
-Users can specify parameter values in a pipeline template design to be provided when executing the pipeline instead of having to create and assign parameters when creating a pipeline based of the template. This change empowers platform builders to create more flexible and reusable pipeline templates and improves overall speed of pipeline creation.
+- Alauda Build of Nexus
+
+### Breaking Changes
+
+- Support for the `ClusterTask` object has been removed in this version of `Alauda DevOps Pipeline`.
+- The `OCI ConnectorClass` resolver-type format has changed in `Alauda DevOps Pipeline`, which may affect scenarios using the `OCI connector`.
+- In `Alauda DevOps Connectors`, after upgrading to `v1.1.0`, connectors  created in `v1.0.8` may encounter errors. For more details, please refer  to [Release Notes](https://docs.alauda.io/alauda-devops-connectors/1.1/overview/release_notes.html#services-c-xxx-already-exist).
+
+### Fixed Issues
+
+- Fixed an issue in `Alauda DevOps Pipeline` where the `ConfigMap` key  displayed in the UI did not match the actual execution.
+- Fixed several issues in `Alauda DevOps Pipeline`, including failure to delete `Tekton` components, trigger resources not being automatically  imported, and the creation of zombie processes by tekton-hub-api.
+- Fixed several stability-related issues in `Alauda DevOps Pipeline`.
+
+### Known Issues
+
+No issues in this release.

--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -40,7 +40,7 @@ The table below shows the version matrix of the `Operators` included in `Alauda 
 - Supports using the `OCI Connector` when pulling images in `Kubernetes`.
 - Adds a new `Kubernetes Connector` to integrate with `Kubernetes` clusters and use it in workloads/pipelines.
 
-#### DevOps Toolchain 
+#### DevOps Toolchain
 
 This update enhances the overall security and stability of the toolchain, which includes the following:
 
@@ -55,8 +55,8 @@ This update enhances the overall security and stability of the toolchain, which 
 ### Breaking Changes
 
 - Support for the `ClusterTask` object has been removed in this version of `Alauda DevOps Pipeline`.
-- The `OCI ConnectorClass` resolver-type format has changed in `Alauda DevOps Pipeline`, which may affect scenarios using the `OCI connector`.
-- In `Alauda DevOps Connectors`, after upgrading to `v1.1.0`, connectors  created in `v1.0.8` may encounter errors. For more details, please refer  to [Release Notes](https://docs.alauda.io/alauda-devops-connectors/1.1/overview/release_notes.html#services-c-xxx-already-exist).
+- The `OCI ConnectorClass` resolver-type format has changed in `Alauda DevOps Connectors`, which may affect scenarios using the `OCI connector`.
+- In `Alauda DevOps Connectors`, after upgrading to `v1.1.0`, connectors  created in `v1.0.8` may encounter errors.
 
 ### Fixed Issues
 

--- a/doom.config.yml
+++ b/doom.config.yml
@@ -22,8 +22,14 @@ releaseNotes:
     unfixed: |
       project = <%= project %> AND affectedVersion in ("<%= version %>") AND type = Bug AND status in (Cancelled) AND ReleaseNotesStatus = Publish
 
+    unfixedIssues: |
+      project = <%= project %> AND (<%- version %>) AND type = Bug AND status in (Cancelled) AND ReleaseNotesStatus = Publish
+
     fixed: |
       project = <%= project %> AND fixVersion in ("<%= version %>") AND type = Bug AND status in (Done, Resolved) AND ReleaseNotesStatus = Publish
+
+    fixedIssues: |
+      project = <%= project %> AND (<%- version %>) AND type = Bug AND status in (Done, Resolved) AND ReleaseNotesStatus = Publish
 translate:
   # 系统提示语，ejs 模板，传入的参数有 `sourceLang`, `targetLang`, `additionalPrompts`
   # 其中 `sourceLang` 和 `targetLang` 是 `中文` 和 `英文` 两个字符串，

--- a/sites.yaml
+++ b/sites.yaml
@@ -3,7 +3,7 @@
     en: Alauda DevOps Pipelines
     zh: Alauda DevOps Pipelines
   base: /alauda-devops-pipelines
-  version: v4.0
+  version: v4.2
   repo: https://github.com/AlaudaDevops/tektoncd-operator
   image: devops/alauda-devops-pipelines-docs
 - name: alauda-devops-connectors
@@ -11,7 +11,7 @@
     en: Alauda DevOps Connectors
     zh: Alauda DevOps Connectors
   base: /alauda-devops-connectors
-  version: v1.0
+  version: v1.2
   repo: https://github.com/AlaudaDevops/connectors-operator
   image: devops/alauda-devops-connectors-docs
 - name: alauda-build-of-gitlab
@@ -19,7 +19,7 @@
     en: Alauda Build of Gitlab
     zh: Alauda Build of Gitlab
   base: /alauda-build-of-gitlab
-  version: v17.8
+  version: v17.11
   repo: https://github.com/AlaudaDevops/gitlab-ce-operator
   image: devops/alauda-build-of-gitlab-docs
 - name: alauda-build-of-harbor
@@ -35,7 +35,7 @@
     en: Alauda Build of Nexus
     zh: Alauda Build of Nexus
   base: /alauda-build-of-nexus
-  version: v3.76
+  version: v3.81
   repo: https://github.com/AlaudaDevops/nexus-ce-operator
   image: devops/alauda-build-of-nexus-docs
 - name: alauda-build-of-sonarqube
@@ -48,4 +48,4 @@
   image: devops/alauda-build-of-sonarqube-docs
 - name: container_platform
   base: /container_platform
-  version: v4.0
+  version: v4.1


### PR DESCRIPTION
docs:update Alauda DevOps (Next-Gen) v4.1 release notes and sites.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated lifecycle policy heading to 4.1.
  * Revamped release notes for Next-Gen v4.1: aggregated overview, updated front-matter/title, compatibility/support matrix, reorganized features (Pipeline, Connectors, Toolchain), and explicit Breaking Changes, Fixed Issues, and Known Issues sections; removed legacy per-build entries and template parameters.

* **Chores**
  * Bumped site version references: Pipelines v4.2, Connectors v1.2, GitLab v17.11, Nexus v3.81, Container Platform v4.1.
  * Added release-notes query templates for fixed/unfixed issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->