### PR TITLE
docs: update DevOps v3.20 plugin release notes

### DIFF
--- a/docs/en/install/installing-devops.mdx
+++ b/docs/en/install/installing-devops.mdx
@@ -243,6 +243,33 @@ spec:
 
 This configuration directs Katanomi components to use /tmp/audit as the audit log storage path, ensuring compatibility with environments that enforce a read-only root filesystem. Adjust the path as needed to meet your security and operational requirements.
 
+### How to Configure Custom Scheduling Policies for Katanomi \{#how-to-configure-custom-scheduling-policies-for-katanomi}
+
+To schedule Katanomi components on specific nodes, configure `nodeSelector`, `tolerations`, or `affinity` under `spec.helmValues.global`. For example:
+
+```yaml
+spec:
+  helmValues:
+    global:
+      nodeSelector:
+        custom.node/role: devops
+      tolerations:
+        - key: custom-taint
+          operator: Exists
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: custom.node/role
+                    operator: In
+                    values:
+                      - devops
+```
+
+If these fields are not configured, Katanomi components continue to use the default scheduling policy.
+
 ### How to Configure a Custom ImagePullSecret When Deploying Katanomi
 
 To specify a custom ImagePullSecret for your Katanomi instance, add the following configuration:

--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -13,18 +13,19 @@ weight: 20
 - Users can integrate `Alauda DevOps Jenkins v3` & `Alauda DevOps v3` with the newest DevOps Toolchain.
 - Pipeline execution forms support filling in default values.
 - The `Builds` and `Releases` pipeline has refactored the parameter rendering logic, and the parameters support referencing artifact attribute values and mapping expressions.
+- In `Alauda DevOps v3.20.36`, Katanomi components support custom scheduling policies through the Katanomi CR, including `nodeSelector`, `tolerations`, and `affinity`. Default scheduling behavior remains unchanged when these options are not configured. For an example, see [How to Configure Custom Scheduling Policies for Katanomi](../install/installing-devops.mdx#how-to-configure-custom-scheduling-policies-for-katanomi).
 
 Other changes:
 
 - Fixed vulnerabilities in `Alauda DevOps v3`, `Alauda DevOps Jenkins v3` and `Alauda DevOps Eventing v3`.
 
-The newest version of plugins are as follows:
+The newest versions of plugins are as follows:
 
-| Plugin Name | Latest Plugin Version |
-| - | - |
-| Alauda DevOps v3 | 3.20.35 |
-| Alauda DevOps Jenkins v3 | 3.20.17 |
-| Alauda DevOps Eventing v3 | 3.20.8 |
+| Plugin Name | Latest Plugin Version | ACP Version |
+| - | - | - |
+| Alauda DevOps v3 | 3.20.36 | 4.0, 4.1, 4.2, 4.3 |
+| Alauda DevOps Jenkins v3 | 3.20.18 | 4.0, 4.1, 4.2, 4.3 |
+| Alauda DevOps Eventing v3 | 3.20.9 | 4.0, 4.1, 4.2, 4.3 |
 
 ### Breaking Changes
 


### PR DESCRIPTION
## Summary
- Update DevOps v3 plugin latest versions and ACP compatibility matrix.
- Add release note for Katanomi custom scheduling support in Alauda DevOps v3.20.36.
- Add an installation FAQ example for Katanomi custom scheduling policies.

## Validation
- git diff --check
- yarn lint
- yarn build