### PR TITLE
docs: correct Jenkins plugin version

### DIFF
--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -24,7 +24,7 @@ The newest versions of plugins are as follows:
 | Plugin Name | Latest Plugin Version | ACP Version |
 | - | - | - |
 | Alauda DevOps v3 | 3.20.36 | 4.0, 4.1, 4.2, 4.3 |
-| Alauda DevOps Jenkins v3 | 3.20.18 | 4.0, 4.1, 4.2, 4.3 |
+| Alauda DevOps Jenkins v3 | 3.20.19 | 4.0, 4.1, 4.2, 4.3 |
 | Alauda DevOps Eventing v3 | 3.20.9 | 4.0, 4.1, 4.2, 4.3 |
 
 ### Breaking Changes


### PR DESCRIPTION
## Summary
- Correct Alauda DevOps Jenkins v3 latest plugin version from 3.20.18 to 3.20.19 in release notes.

## Validation
- Verified no 3.20.18 references remain in the repository.