### PR TITLE
docs: register sre-agent as a subsite (main branch only)

### DIFF
--- a/docs/en/sre-agent/about.mdx
+++ b/docs/en/sre-agent/about.mdx
@@ -1,0 +1,7 @@
+---
+weight: 710
+---
+
+# About Alauda SRE Agent
+
+<ExternalSite name="alauda-sre-agent" />

--- a/docs/en/sre-agent/index.mdx
+++ b/docs/en/sre-agent/index.mdx
@@ -1,0 +1,7 @@
+---
+weight: 700
+---
+
+# SRE Agent
+
+<Overview overviewHeaders={[]} />

--- a/sites.yaml
+++ b/sites.yaml
@@ -46,6 +46,14 @@
   version: v2026.1
   repo: https://github.com/AlaudaDevops/sonarqube-ce-operator
   image: devops/alauda-build-of-sonarqube-docs
+- name: alauda-sre-agent
+  displayName:
+    en: Alauda SRE Agent
+    zh: Alauda SRE Agent
+  base: /alauda-sre-agent
+  version: main
+  repo: https://github.com/AlaudaDevops/sre-agent-langgraph
+  image: devops/alauda-sre-agent-docs
 - name: container_platform
   base: /container_platform
   version: v4.3


### PR DESCRIPTION
## What

按子站点（subsite）机制注册 SRE Agent 文档（`AlaudaDevops/sre-agent-langgraph`），让它能在 docs-dev 预览环境里从主站 main 分支点进去预览。

变更（仅 3 个文件）：
- `sites.yaml`：新增 `alauda-sre-agent` 子站点条目
- `docs/en/sre-agent/index.mdx`：`<Overview />` 入口
- `docs/en/sre-agent/about.mdx`：`<ExternalSite name="alauda-sre-agent" />` 导航入口

## Why / 范围约束

按永松的意见，这次刻意**只在 main 分支注册、只构建 main**：
- 本 PR 改动**不要 cherry-pick 到 `release-*` 分支**；
- sre-agent 文档站点**暂时只用 main 分支，不发 release 分支**。

目的是 sre-agent 还没正式产品化，先给实施同学一个在线预览文档的地方，不污染正式发布的 release 文档。

## ⚠️ 需 reviewer 确认的两点

1. **`version: main`** —— 现有子站都是 `vX.Y` 对应各自的 `release-vX.Y` 分支；sre-agent 只有 main，这里填了 `main`。`product-docs-pipeline` 解析 `image:version` 拉 main-only 站点用的约定，请帮忙确认这个值是否正确。
2. **`image: devops/alauda-sre-agent-docs` 目前不存在** —— `sre-agent-langgraph` 仓库 `docs/` 下只有内容，还没有 doom product-doc 构建配置和 `.tekton` 文档流水线。需要先在该仓库 main 分支补一套文档构建产出这个镜像，否则注册了也拉不到内容。镜像名如需调整请指出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Alauda SRE Agent documentation pages, including overview and detailed guides to help users understand the agent's functionality and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->