### PR TITLE
Register Artifact Hub Shim docs site

### DIFF
--- a/docs/en/artifacthub-shim/about.mdx
+++ b/docs/en/artifacthub-shim/about.mdx
@@ -1,0 +1,7 @@
+---
+weight: 130
+---
+
+# About Alauda DevOps Artifact Hub Shim
+
+<ExternalSite name="alauda-devops-artifacthub-shim" />

--- a/docs/en/artifacthub-shim/index.mdx
+++ b/docs/en/artifacthub-shim/index.mdx
@@ -1,0 +1,7 @@
+---
+weight: 120
+---
+
+# Artifact Hub Shim
+
+<Overview overviewHeaders={[]} />

--- a/sites.yaml
+++ b/sites.yaml
@@ -6,6 +6,14 @@
   version: v4.10
   repo: https://github.com/AlaudaDevops/tektoncd-operator
   image: devops/alauda-devops-pipelines-docs
+- name: alauda-devops-artifacthub-shim
+  displayName:
+    en: Alauda DevOps Artifact Hub Shim
+    zh: Alauda DevOps Artifact Hub Shim
+  base: /alauda-devops-artifacthub-shim
+  version: main
+  repo: https://github.com/AlaudaDevops/artifacthub-shim
+  image: devops/alauda-devops-artifacthub-shim-docs
 - name: alauda-devops-connectors
   displayName:
     en: Alauda DevOps Connectors


### PR DESCRIPTION
## Summary
- Register the Artifact Hub Shim documentation subsite in sites.yaml.
- Add the parent DevOps docs entry pages for the subsite.

## Verification
- yarn install --immutable
- yarn lint
- sites.yaml parsing and duplicate name/base check
- git diff --check

## Notes
- yarn build is blocked in this environment because docs/en/overview/release_notes.mdx requires JIRA_USERNAME and JIRA_PASSWORD.
- Checked ../artifacthub-shim origin/main: doc-build matches push events on main/master/release branches and uses doc-base alauda-devops-artifacthub-shim, which matches this registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced new documentation for Alauda DevOps Artifact Hub Shim, including overview and about pages with complete information architecture.
  * Registered new documentation site with routing configuration and localized content support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->